### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,7 @@ language: java
 
 jdk:
   - openjdk8
+
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.